### PR TITLE
Add more fields to Asset editing modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The missing media library for Sanity. With support for filters per tag and exten
 - View/Edit your assets in once single place:
   - View asset details
   - Add alt tags to your image in a central place
+  - Add location and attribution information, change title
 - Grid view and list view (with more details):
   - Sort by latest or alphabetically
   - Search by alt, tag, or file name
@@ -31,6 +32,8 @@ The missing media library for Sanity. With support for filters per tag and exten
 - Quick action: Double click an asset to trigger it's primary action
 - Customizable theme:
   - Comes with a dark and light theme, both are fully customizable.
+- Customizable interface
+  - Hide unused asset fields
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The missing media library for Sanity. With support for filters per tag and exten
 - Customizable theme:
   - Comes with a dark and light theme, both are fully customizable.
 - Customizable interface
+  - Define custom fields (text, number, checkbox, textarea are currently supported)
   - Hide unused asset fields
 
 ## Installation
@@ -112,6 +113,41 @@ Example with themeChanges:
     "bottomBarBorderColor": "hotpink",
     "buttonPrimaryBorderColor": "hotpink"
   }
+}
+```
+
+Example with asset fields listed and custom fields added:
+```json
+{
+  "theme": "dark",
+  "themeChanges": {},
+  "assetFields": {
+    title: true,
+    alt: true,
+    location: true,
+    attribution: true,
+    tags: true
+  },
+  "customAssetFields": [
+    {
+      "name": "description",
+      "label": "Additional description",
+      "type": "textarea"
+    },
+    {
+      "name": "decade",
+      "label": "Decade when photo captured",
+      "type": "number",
+      "min": 1800,
+      "max": 2200,
+      "step": 10
+    },
+    {
+      "name": "premiumPhoto",
+      "label": "Is a premium photo",
+      "type": "checkbox"
+    }
+  ]
 }
 ```
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -114,7 +114,7 @@ export const App = ({ onClose, onSelect, selectedAssets, tool }: Props) => {
       setLoading(true);
       const types = tool ? '"sanity.imageAsset", "sanity.fileAsset"' : '"sanity.imageAsset"';
       const newAssets: Array<Asset> = await client.fetch(
-        `*[_type in [${types}]] { _createdAt, _id, _type, alt, location, attribution, extension, metadata, originalFilename, title, size, tags, url }`,
+        `*[_type in [${types}]] { _createdAt, _id, _type, alt, location, attribution, extension, metadata, originalFilename, title, size, tags, url, attributes }`,
         {}
       );
       setAssets(newAssets);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,9 +58,11 @@ export const App = ({ onClose, onSelect, selectedAssets, tool }: Props) => {
 
     if (searchQuery && searchQuery !== '') {
       newFilteredAssets = newFilteredAssets.filter(
-        ({ alt, originalFilename, tags }) =>
+        ({ alt, originalFilename, title, attribution, tags }) =>
           originalFilename.toUpperCase().indexOf(searchQuery.toUpperCase()) > -1 ||
+          (title || '').toUpperCase().indexOf(searchQuery.toUpperCase()) > -1 ||
           (alt || '').toUpperCase().indexOf(searchQuery.toUpperCase()) > -1 ||
+          (attribution || '').toUpperCase().indexOf(searchQuery.toUpperCase()) > -1 ||
           (tags?.join(',') || '').toUpperCase().indexOf(searchQuery.toUpperCase()) > -1
       );
     }
@@ -78,11 +80,11 @@ export const App = ({ onClose, onSelect, selectedAssets, tool }: Props) => {
     }
 
     if (sort === 'az') {
-      newFilteredAssets.sort((a, b) => (a.originalFilename.localeCompare(b.originalFilename) ? -1 : 1));
+      newFilteredAssets.sort((a, b) => ((a.title || a.originalFilename).localeCompare((b.title || b.originalFilename)) ? -1 : 1));
     }
 
     if (sort === 'za') {
-      newFilteredAssets.sort((a, b) => (a.originalFilename.localeCompare(b.originalFilename) ? 1 : -1));
+      newFilteredAssets.sort((a, b) => ((a.title || a.originalFilename).localeCompare((b.title || b.originalFilename)) ? 1 : -1));
     }
 
     setFilteredAssets(newFilteredAssets);
@@ -112,7 +114,7 @@ export const App = ({ onClose, onSelect, selectedAssets, tool }: Props) => {
       setLoading(true);
       const types = tool ? '"sanity.imageAsset", "sanity.fileAsset"' : '"sanity.imageAsset"';
       const newAssets: Array<Asset> = await client.fetch(
-        `*[_type in [${types}]] { _createdAt, _id, _type, alt, location, extension, metadata, originalFilename, size, tags, url }`,
+        `*[_type in [${types}]] { _createdAt, _id, _type, alt, location, attribution, extension, metadata, originalFilename, title, size, tags, url }`,
         {}
       );
       setAssets(newAssets);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -112,7 +112,7 @@ export const App = ({ onClose, onSelect, selectedAssets, tool }: Props) => {
       setLoading(true);
       const types = tool ? '"sanity.imageAsset", "sanity.fileAsset"' : '"sanity.imageAsset"';
       const newAssets: Array<Asset> = await client.fetch(
-        `*[_type in [${types}]] { _createdAt, _id, _type, alt, extension, metadata, originalFilename, size, tags, url }`,
+        `*[_type in [${types}]] { _createdAt, _id, _type, alt, location, extension, metadata, originalFilename, size, tags, url }`,
         {}
       );
       setAssets(newAssets);

--- a/src/components/AssetModal.tsx
+++ b/src/components/AssetModal.tsx
@@ -1,8 +1,8 @@
-import { Asset } from '../types/Asset';
+import { Asset, Geopoint } from '../types/Asset';
 import { Button } from './Button';
 import { formatDate, formatSize } from '../shared/utils';
 import { Icon } from './Icon';
-import { LabelWithInput } from './LabelWithInput';
+import { LabelWithInput, LabelWithLocationInput } from './LabelWithInput';
 import { Loader } from './Loader';
 import { Modal } from './Modal';
 import client from 'part:@sanity/base/client';
@@ -102,12 +102,13 @@ const StyledButtonsContainer = styled.div`
 `;
 
 export const AssetModal = ({ asset, loading, handleError, onClose, onSaveComplete, setLoading }: Props) => {
-  const { _createdAt, _id, _type, alt, extension, metadata, originalFilename, size, tags, url } = asset;
+  const { _createdAt, _id, _type, alt, extension, metadata, originalFilename, size, tags, url, location } = asset;
   const { height, width } = metadata?.dimensions || {};
   const [localAlt, setLocalAlt] = useState<string>(alt || '');
+  const [localLocation, setLocalLocation] = useState<Geopoint>(location || {});
   const [localTags, setLocalTags] = useState<string>((tags || []).join(',') || '');
 
-  const isChanged = localAlt !== (alt || '') || localTags !== (tags?.join(',') || '');
+  const isChanged = localAlt !== (alt || '') || localLocation !== (location || {}) || localTags !== (tags?.join(',') || '');
 
   async function handleSubmit(e: FormEvent) {
     try {
@@ -123,9 +124,10 @@ export const AssetModal = ({ asset, loading, handleError, onClose, onSaveComplet
       }
 
       const alt = localAlt;
+      const location = localLocation;
       const tags = localTags.split(',').map((v) => v.trim());
 
-      await client.patch(_id).set({ alt, tags }).commit();
+      await client.patch(_id).set({ alt, location, tags }).commit();
       onSaveComplete();
     } catch (e) {
       handleError(e);
@@ -170,6 +172,11 @@ export const AssetModal = ({ asset, loading, handleError, onClose, onSaveComplet
               value={localAlt}
             />
           )}
+          <LabelWithLocationInput
+            label="Location"
+            onChange={setLocalLocation}
+            value={localLocation}
+          />
           <LabelWithInput
             label="Tags"
             onChange={setLocalTags}

--- a/src/components/AssetModal.tsx
+++ b/src/components/AssetModal.tsx
@@ -160,7 +160,7 @@ export const AssetModal = ({ asset, loading, handleError, onClose, onSaveComplet
   function renderAttributes(attribute: CustomAssetField) {
     const handleChange = (value: any) => setLocalAttributes(prevState => ({
       ...prevState,
-      [attribute.name]: attribute.type === 'number' && value ? parseFloat(value) : value
+      [attribute.name]: value
     }))
     switch(attribute.type) {
       case 'checkbox':

--- a/src/components/AssetModal.tsx
+++ b/src/components/AssetModal.tsx
@@ -204,7 +204,7 @@ export const AssetModal = ({ asset, loading, handleError, onClose, onSaveComplet
               value={localLocation}
             />
           )}
-          {assetFields.location && (
+          {assetFields.tags && (
             <LabelWithInput
               label="Tags"
               onChange={setLocalTags}

--- a/src/components/AssetModal.tsx
+++ b/src/components/AssetModal.tsx
@@ -88,7 +88,7 @@ const StyledInfoContainer = styled.div`
   font-size: 14px;
   font-weight: 400;
   line-height: 1.4;
-˝
+
   & strong {
     color: ${({ theme }) => theme.assetModalInfoTitleColor};
     display: block;

--- a/src/components/AssetModal.tsx
+++ b/src/components/AssetModal.tsx
@@ -87,6 +87,10 @@ const StyledInfoContainer = styled.div`
 `;
 
 const StyledInputsContainer = styled.div`
+  padding-right: 8px !important;
+  max-height: 300px;
+  overflow: hidden scroll;
+
   & > :not(:last-child) {
     margin: 0 0 20px;
   }

--- a/src/components/AssetModal.tsx
+++ b/src/components/AssetModal.tsx
@@ -214,6 +214,7 @@ export const AssetModal = ({ asset, loading, handleError, onClose, onSaveComplet
               onChange={setLocalAlt}
               placeholder={!localAlt ? 'No alt text yet...' : undefined}
               value={localAlt}
+              type="textarea"
             />
           )}
           {assetFields.attribution && (

--- a/src/components/LabelWithInput.tsx
+++ b/src/components/LabelWithInput.tsx
@@ -1,13 +1,30 @@
 import React from 'react';
 import { Geopoint } from 'src/types/Asset';
 import styled from 'styled-components';
+
 interface Props {
   label: string;
-  onChange: (value: string) => void;
   placeholder?: string;
-  type?: 'text';
-  value?: string | number | readonly string[] | undefined;
+  onChange: (value: any) => void;
+  value?: string | number | boolean | readonly string[] | undefined;
 }
+interface PropsText extends Props {
+  type?: 'text' | 'textarea';
+  onChange: (value: string) => void;
+  value?: string | readonly string[] | undefined;
+}
+interface PropsNumber extends Props {
+  onChange: (value: number) => void;
+  value?: number;
+    max?: number;
+    min?: number;
+    step?: number | 'any';
+}
+interface PropsCheckbox extends Props {
+  onChange: (value: boolean) => void;
+  value?: boolean | undefined;
+}
+
 
 const StyledContainer = styled.label`
   cursor: pointer;
@@ -15,20 +32,22 @@ const StyledContainer = styled.label`
   width: 100%;
 `;
 
-const StyledWrapper = styled.div`
-  cursor: pointer;
+const StyledContainerRow = styled(StyledContainer)`
   display: flex;
   align-items: center;
-  width: 100%;
+
+  & > input {
+    margin-left: 16px;
+  }
+`;
+
+const StyledWrapper = styled(StyledContainerRow)`
   margin-bottom: 8px;
 
   & > span {
     font-size: 14px;
     margin: 0;
     opacity: 0.8;
-  }
-  & > input {
-    margin-left: 16px;
   }
 `;
 
@@ -56,11 +75,39 @@ const StyledInput = styled.input`
   width: 100%;
 `;
 
-export const LabelWithInput = ({ label, onChange, placeholder, value = '', type = 'text' }: Props) => (
+const StyledTextarea = styled.textarea`
+  background-color: ${({ theme }) => theme.inputBackgroundColor};
+  border-radius: ${({ theme }) => theme.appBorderRadius};
+  border: 0;
+  color: ${({ theme }) => theme.inputTextColor};
+  font-family: ${({ theme }) => theme.appFontFamily};
+  font-size: 16px;
+  line-height: 1.1;
+  outline: 0;
+  padding: 16px;
+  width: 100%;
+`;
+
+export const LabelWithInput = ({ label, onChange, placeholder, value = '', type = 'text'}: PropsText) => (
   <StyledContainer>
     <StyledLabel>{label}</StyledLabel>
-    <StyledInput onChange={(e) => onChange(e.target.value)} placeholder={placeholder} value={value} type={type} />
+    {type === 'textarea'
+      ? <StyledTextarea onChange={(e) => onChange(e.target.value)} value={value} placeholder={placeholder} />
+      : <StyledInput onChange={(e) => onChange(e.target.value)} placeholder={placeholder} value={value} type={type} />
+    }
   </StyledContainer>
+);
+export const LabelWithNumericalInput = ({ label, onChange, placeholder, value,  min, max, step}: PropsNumber) => (
+  <StyledContainer>
+    <StyledLabel>{label}</StyledLabel>
+    <StyledInput onChange={(e) => onChange(parseFloat(e.target.value))} placeholder={placeholder} value={value} type='number' min={min} max={max} step={step}/>
+  </StyledContainer>
+);
+export const LabelWithCheckbox = ({ label, onChange, value = undefined }: PropsCheckbox) => (
+  <StyledContainerRow>
+    <StyledLabel>{label}</StyledLabel>
+    <input onChange={(e) => onChange(e.target.checked)} checked={value} type='checkbox' />
+  </StyledContainerRow>
 );
 
 interface LocationProps {
@@ -78,7 +125,7 @@ export const LabelWithLocationInput = ({ label, onChange, value = { lat: undefin
     }))
   }
   return (
-    <StyledContainer>
+    <StyledContainer as="div">
       <StyledLabel>{label}</StyledLabel>
       <StyledWrapper>
         <StyledLabel>Latitude</StyledLabel>

--- a/src/components/LabelWithInput.tsx
+++ b/src/components/LabelWithInput.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
+import { Geopoint } from 'src/types/Asset';
 import styled from 'styled-components';
-
 interface Props {
   label: string;
   onChange: (value: string) => void;
@@ -13,6 +13,22 @@ const StyledContainer = styled.label`
   cursor: pointer;
   display: block;
   width: 100%;
+`;
+
+const StyledWrapper = styled.div`
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  margin-bottom: 8px;
+
+  > ${styled.span} {
+    font-size: 14px;
+    margin: 0;
+  }
+  > ${styled.input} {
+    margin-left: 16px;
+  }
 `;
 
 const StyledLabel = styled.span`
@@ -45,3 +61,36 @@ export const LabelWithInput = ({ label, onChange, placeholder, value = '', type 
     <StyledInput onChange={(e) => onChange(e.target.value)} placeholder={placeholder} value={value} type={type} />
   </StyledContainer>
 );
+
+interface LocationProps {
+  label: string;
+  onChange: (value: (Geopoint | ((prevState: Geopoint) => Geopoint))) => void
+  value?: Geopoint | undefined;
+}
+
+export const LabelWithLocationInput = ({ label, onChange, value = { lat: undefined, lng: undefined, alt: undefined } }: LocationProps) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target
+    onChange(prevState => ({
+        ...prevState,
+        [name]: parseFloat(value)
+    }))
+  }
+  return (
+    <StyledContainer>
+      <StyledLabel>{label}</StyledLabel>
+      <StyledWrapper>
+        <StyledLabel>Latitude</StyledLabel>
+        <StyledInput name="lat" onChange={handleChange} value={value.lat || ''} type="number" step="any" />
+      </StyledWrapper>
+      <StyledWrapper>
+        <StyledLabel>Longitude</StyledLabel>
+        <StyledInput name="lng" onChange={handleChange} value={value.lng || ''} type="number" step="any" />
+      </StyledWrapper>
+      <StyledWrapper>
+        <StyledLabel>Altitude</StyledLabel>
+        <StyledInput name="alt" onChange={handleChange} value={value.alt || ''} type="number" step="any" />
+      </StyledWrapper>
+    </StyledContainer>
+  )
+};

--- a/src/components/LabelWithInput.tsx
+++ b/src/components/LabelWithInput.tsx
@@ -22,11 +22,12 @@ const StyledWrapper = styled.div`
   width: 100%;
   margin-bottom: 8px;
 
-  > ${styled.span} {
+  & > span {
     font-size: 14px;
     margin: 0;
+    opacity: 0.8;
   }
-  > ${styled.input} {
+  & > input {
     margin-left: 16px;
   }
 `;

--- a/src/components/MediaGrid.tsx
+++ b/src/components/MediaGrid.tsx
@@ -96,6 +96,7 @@ export const MediaGrid = ({
             onDoubleClick={() => onDoubleClick(asset)}
             selected={selectedAssets.findIndex(({ _id }) => _id === asset._id) > -1}
             {...asset}
+            title={asset.title || asset.originalFilename}
           />
         </DraggableMediaItem>
       );
@@ -109,9 +110,9 @@ const ImageItem = ({ alt, onClick, onDoubleClick, selected, url }: MediaItemProp
   </StyledMediaItem>
 );
 
-const FileItem = ({ originalFilename, onClick, onDoubleClick, selected }: MediaItemProps) => (
+const FileItem = ({ title, onClick, onDoubleClick, selected }: MediaItemProps) => (
   <StyledMediaItem selected={selected} onClick={(e) => onClick(e)} onDoubleClick={onDoubleClick}>
     <Icon type="file" />
-    <div>{originalFilename}</div>
+    <div>{title}</div>
   </StyledMediaItem>
 );

--- a/src/components/MediaGrid.tsx
+++ b/src/components/MediaGrid.tsx
@@ -80,6 +80,7 @@ export const MediaGrid = ({
       const Element = asset._type === 'sanity.imageAsset' ? ImageItem : FileItem;
       return (
         <DraggableMediaItem
+          key={asset._id}
           _type={asset._type}
           onDragEnd={() => setIsDraggingMediaItem(false)}
           onDragStart={() => {

--- a/src/components/MediaList.tsx
+++ b/src/components/MediaList.tsx
@@ -108,6 +108,7 @@ export const MediaList = ({
     <MediaListHeader />
     {assets.map((asset) => (
       <DraggableMediaItem
+        key={asset._id}
         _type={asset._type}
         onDragEnd={() => setIsDraggingMediaItem(false)}
         onDragStart={() => {

--- a/src/components/MediaList.tsx
+++ b/src/components/MediaList.tsx
@@ -124,6 +124,7 @@ export const MediaList = ({
           onDoubleClick={() => onDoubleClick(asset)}
           selected={selectedAssets.findIndex(({ _id }) => _id === asset._id) > -1}
           {...asset}
+          title={asset.title || asset.originalFilename}
         />
       </DraggableMediaItem>
     ))}
@@ -133,7 +134,7 @@ export const MediaList = ({
 const MediaListHeader = () => (
   <StyledHeader>
     <div />
-    <div>Filename</div>
+    <div>Title / Filename</div>
     <div>Alt</div>
     <div>Tags</div>
     <div>Dimensions</div>
@@ -151,7 +152,7 @@ const MediaRow = ({
   metadata,
   onClick,
   onDoubleClick,
-  originalFilename,
+  title,
   selected,
   size,
   tags = [],
@@ -172,7 +173,7 @@ const MediaRow = ({
           )}
         </StyledThumbnailContainer>
       </div>
-      <div>{originalFilename}</div>
+      <div>{title}</div>
       <div>{alt}</div>
       <div>{tags.join(', ')}</div>
       <div>{width && height && `${width} x ${height}`}</div>

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -38,7 +38,7 @@ export const SearchBar = ({ searchQuery, setSearchQuery }: Props) => (
     <StyledInput
       value={searchQuery}
       onChange={(e) => setSearchQuery(e.target.value)}
-      placeholder="Search by alt, tags or filename"
+      placeholder="Search by title, alt, attribution, tags or filename"
       type="search"
     />
   </StyledContainer>

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,13 @@
 import config from 'config:media-library';
 
-export const { theme = 'dark', themeChanges = {} } = config;
+export const {
+  theme = 'dark',
+  themeChanges = {},
+  assetFields = {
+    title: true,
+    alt: true,
+    location: true,
+    attribution: true,
+    tags: true
+  }
+} = config;

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,5 +9,6 @@ export const {
     location: true,
     attribution: true,
     tags: true
-  }
+  },
+  customAssetFields = []
 } = config;

--- a/src/types/Asset.ts
+++ b/src/types/Asset.ts
@@ -5,6 +5,10 @@ export type Geopoint = {
   lng?: number
   alt?: number
 }
+
+export type Attributes = {
+  [_id: string]: string | boolean | number | undefined
+}
 export interface Asset {
   _createdAt: string;
   _id: string;
@@ -24,4 +28,5 @@ export interface Asset {
   attribution?: string;
   tags?: Array<string>;
   url: string;
+  attributes: Attributes
 }

--- a/src/types/Asset.ts
+++ b/src/types/Asset.ts
@@ -18,8 +18,10 @@ export interface Asset {
     };
   };
   originalFilename: string;
+  title?: string;
   size: number;
   location?: Geopoint;
+  attribution?: string;
   tags?: Array<string>;
   url: string;
 }

--- a/src/types/Asset.ts
+++ b/src/types/Asset.ts
@@ -1,5 +1,10 @@
 export type AssetType = 'sanity.imageAsset' | 'sanity.fileAsset';
 
+export type Geopoint = {
+  lat?: number
+  lng?: number
+  alt?: number
+}
 export interface Asset {
   _createdAt: string;
   _id: string;
@@ -14,6 +19,7 @@ export interface Asset {
   };
   originalFilename: string;
   size: number;
+  location?: Geopoint;
   tags?: Array<string>;
   url: string;
 }


### PR DESCRIPTION
Firstly, brilliant plugin, a pleasure to use and edit!

Key features:
- Added new fields to Asset editing modal
  - Title (defaults to original filename)
  - Location (set a geopoint Latitude, Longitude, Altitude)
  - Attribution
- Asset editing modal now has overflow set
- All fields can be toggled on/off in the config!

![image](https://user-images.githubusercontent.com/18035115/103565051-860e5500-4eb7-11eb-9960-047567cd1ae5.png)

TODO: Add a custom metadata field for projects?

Happy to talk about development of this further!