### PR TITLE
add missing month and remove wrong month index

### DIFF
--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -7,6 +7,6 @@ export function formatSize(size: number) {
 
 export function formatDate(date: string) {
   const d = new Date(date);
-  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-  return `${months[d.getMonth() - 1]} ${d.getDate()}, ${d.getFullYear()}`;
+  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+  return `${months[d.getMonth()]} ${d.getDate()}, ${d.getFullYear()}`;
 }


### PR DESCRIPTION
before
![image](https://user-images.githubusercontent.com/580312/105710253-1ec44d80-5f17-11eb-9b3c-5cedc0f3cc0d.png)

after
![image](https://user-images.githubusercontent.com/580312/105710229-19670300-5f17-11eb-841e-ac9f72cb9f9b.png)

(better) alternative is to use `d.toLocaleString('default', { month: 'short' })`, but that won't work in IE11.

this fixes #10 