### PR TITLE
add loading=lazy to thumbnails in mediagrid and medialist

### DIFF
--- a/src/components/MediaGrid.tsx
+++ b/src/components/MediaGrid.tsx
@@ -105,7 +105,7 @@ export const MediaGrid = ({
 
 const ImageItem = ({ alt, onClick, onDoubleClick, selected, url }: MediaItemProps) => (
   <StyledMediaItem selected={selected} onClick={(e) => onClick(e)} onDoubleClick={onDoubleClick}>
-    <img alt={alt} src={`${url}?w=150&h=150&fit=crop&auto=format&q=80`} />
+    <img alt={alt} src={`${url}?w=150&h=150&fit=crop&auto=format&q=80`} loading="lazy" />
   </StyledMediaItem>
 );
 

--- a/src/components/MediaList.tsx
+++ b/src/components/MediaList.tsx
@@ -165,7 +165,7 @@ const MediaRow = ({
       <div>
         <StyledThumbnailContainer>
           {_type === 'sanity.imageAsset' ? (
-            <StyledImage alt={alt} src={`${url}?w=100&h=100&fit=crop&auto=format&q=80`} />
+            <StyledImage alt={alt} src={`${url}?w=100&h=100&fit=crop&auto=format&q=80`} loading="lazy" />
           ) : (
             <StyledFile>
               <Icon type="file" />


### PR DESCRIPTION
this keeps the cdn requests down with a lot of images