### PR TITLE
add custom fields to local values

### DIFF
--- a/src/components/AssetModal.tsx
+++ b/src/components/AssetModal.tsx
@@ -7,7 +7,7 @@ import { LabelWithInput } from './LabelWithInput';
 import { Loader } from './Loader';
 import { Modal } from './Modal';
 import client from 'part:@sanity/base/client';
-import React, { Fragment, FormEvent, useState } from 'react';
+import React, { Fragment, FormEvent, useState, useEffect } from 'react';
 import styled from 'styled-components';
 
 interface Props {
@@ -114,6 +114,10 @@ export const AssetModal = ({ asset, loading, handleError, onClose, onSaveComplet
     tags: tags?.join(','),
     title,
   });
+
+  useEffect(() => {
+    customFields.map((field: any) => setLocalValues((values) => ({ ...values, [field.name]: asset[field.name] })));
+  }, []);
 
   const inputFields = [
     { name: 'title', label: 'Title', placeholder: 'No title yet' },


### PR DESCRIPTION
custom field values aren't visible inside the edit modal inputs:

before:
![Screenshot 2021-02-01 at 12 35 41](https://user-images.githubusercontent.com/580312/106453814-268d7000-648a-11eb-8476-f29199772030.png)

after:
![Screenshot 2021-02-01 at 12 35 58](https://user-images.githubusercontent.com/580312/106453823-29886080-648a-11eb-9031-5ab8973f6b12.png)
