### PR TITLE
add used/unused filter and dialog messages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -132,10 +132,6 @@ export const App = ({ onClose, onSelect, selectedAssets, tool }: Props) => {
     fetchAssets();
   }, []);
 
-  useEffect(() => {
-    console.log(assets);
-  }, [assets]);
-
   async function fetchAssets() {
     try {
       setLoading(true);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,6 +67,7 @@ export const App = ({ onClose, onSelect, selectedAssets, tool }: Props) => {
     'size',
     'tags',
     'url',
+    '"usedBy": *[references(^._id)] { _id, _type }',
     ...customFields.map(({ name }: { name: string }) => name),
   ];
 
@@ -88,7 +89,12 @@ export const App = ({ onClose, onSelect, selectedAssets, tool }: Props) => {
     }
 
     if (activeTags.length > 0) {
-      newFilteredAssets = newFilteredAssets.filter(({ tags }) => tags?.some((tag) => activeTags.indexOf(tag) > -1));
+      newFilteredAssets = newFilteredAssets.filter(
+        ({ tags, usedBy }) =>
+          tags?.some((tag) => activeTags.indexOf(tag) > -1) ||
+          (activeTags.indexOf('used') > -1 && usedBy.length) ||
+          (activeTags.indexOf('unused') > -1 && !usedBy.length)
+      );
     }
 
     if (sort === 'date') {
@@ -125,6 +131,10 @@ export const App = ({ onClose, onSelect, selectedAssets, tool }: Props) => {
   useEffect(() => {
     fetchAssets();
   }, []);
+
+  useEffect(() => {
+    console.log(assets);
+  }, [assets]);
 
   async function fetchAssets() {
     try {
@@ -248,11 +258,11 @@ export const App = ({ onClose, onSelect, selectedAssets, tool }: Props) => {
     (acc, { extension }) => [...acc, extension]
   );
 
-  const tags: Array<{ isActive: boolean; value: string }> = getUniqueFiltersWithActive(
-    assets,
-    activeTags,
-    (acc, { tags }) => (tags ? [...acc, ...tags] : acc)
-  );
+  const tags: Array<{ isActive: boolean; value: string }> = [
+    { isActive: activeTags.indexOf('used') > -1, value: 'used' },
+    { isActive: activeTags.indexOf('unused') > -1, value: 'unused' },
+    ...getUniqueFiltersWithActive(assets, activeTags, (acc, { tags }) => (tags ? [...acc, ...tags] : acc)),
+  ];
 
   return (
     <StyledContainer>

--- a/src/components/AssetModal.tsx
+++ b/src/components/AssetModal.tsx
@@ -83,7 +83,7 @@ const StyledInfoContainer = styled.div`
     color: ${({ theme }) => theme.assetModalInfoTitleColor};
     display: block;
     font-weight: 500;
-    margin: 0 0 1em;
+    margin: 0 0 0.5em;
   }
 `;
 
@@ -106,8 +106,23 @@ const StyledButtonsContainer = styled.div`
   }
 `;
 
+const StyledUsageLabel = styled.span`
+  background-color: ${({ theme }) => theme.usedLabelBackgroundColor};
+  border-radius: ${({ theme }) => theme.appBorderRadius};
+  color: ${({ theme }) => theme.usedLabelTextColor};
+  display: inline-block;
+  font-weight: 500;
+  line-height: 1;
+`;
+
+const StyledUsageLabelUnused = styled(StyledUsageLabel)`
+  background-color: ${({ theme }) => theme.unusedLabelBackgroundColor};
+  color: ${({ theme }) => theme.unusedLabelTextColor};
+  padding: 3px 5px;
+`;
+
 export const AssetModal = ({ asset, loading, handleError, onClose, onSaveComplete, setLoading }: Props) => {
-  const { _createdAt, _id, _type, alt, extension, metadata, originalFilename, size, tags, title, url } = asset;
+  const { _createdAt, _id, _type, alt, extension, metadata, originalFilename, size, tags, title, url, usedBy } = asset;
   const { height, width } = metadata?.dimensions || {};
   const [localValues, setLocalValues] = useState<{ [key: string]: any }>({
     alt,
@@ -178,6 +193,13 @@ export const AssetModal = ({ asset, loading, handleError, onClose, onSaveComplet
           </StyledThumbnailContainer>
           <StyledInfoContainer>
             <strong>{localValues.title || originalFilename}</strong>
+            {usedBy.length === 0 ? (
+              <StyledUsageLabelUnused>unused</StyledUsageLabelUnused>
+            ) : (
+              <StyledUsageLabel>
+                Used by {usedBy.length} document{usedBy.length === 1 ? '' : 's'}{' '}
+              </StyledUsageLabel>
+            )}
             <br />
             {formatDate(_createdAt)}
             <br />

--- a/src/components/AssetModal.tsx
+++ b/src/components/AssetModal.tsx
@@ -197,7 +197,7 @@ export const AssetModal = ({ asset, loading, handleError, onClose, onSaveComplet
               <StyledUsageLabelUnused>unused</StyledUsageLabelUnused>
             ) : (
               <StyledUsageLabel>
-                Used by {usedBy.length} document{usedBy.length === 1 ? '' : 's'}{' '}
+                Used by {usedBy.length} document{usedBy.length === 1 ? '' : 's'}
               </StyledUsageLabel>
             )}
             <br />

--- a/src/components/DeleteModal.tsx
+++ b/src/components/DeleteModal.tsx
@@ -3,7 +3,7 @@ import { Button } from './Button';
 import { Loader } from './Loader';
 import { Modal } from './Modal';
 import client from 'part:@sanity/base/client';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 interface Props {
@@ -39,6 +39,7 @@ const StyledTitle = styled.h2`
 
 export const DeleteModal = ({ assets, loading, handleError, onClose, onDeleteComplete, setLoading }: Props) => {
   const plural = assets.length > 1;
+  const [usedBy, setUsedBy] = useState(0);
 
   async function onDelete() {
     try {
@@ -56,10 +57,18 @@ export const DeleteModal = ({ assets, loading, handleError, onClose, onDeleteCom
     }
   }
 
+  useEffect(() => {
+    setUsedBy(assets.reduce((prev, cur) => (prev += cur.usedBy.length), 0));
+  }, [assets]);
+
   return (
     <Modal onClose={onClose}>
       <StyledContainer>
         <StyledTitle>Are you sure you want to delete {plural ? 'these assets' : 'this asset'}?</StyledTitle>
+
+        <p>
+          Used by {usedBy} document{usedBy === 1 ? '' : 's'}.
+        </p>
 
         <StyledButtonsContainer>
           <Button disabled={loading} onClick={onDelete}>

--- a/src/themes/darkTheme.ts
+++ b/src/themes/darkTheme.ts
@@ -54,6 +54,6 @@ export const darkTheme = {
   unusedLabelTextColor: colorWhite,
   uploadDropAreaBackgroundColor: 'rgba(0, 0, 0, 0.8)',
   uploadDropAreaIconColor: colorWhite,
-  usedLabelBackgroundColor: colorWhite,
+  usedLabelBackgroundColor: colorBlack,
   usedLabelTextColor: colorGray,
 };

--- a/src/themes/darkTheme.ts
+++ b/src/themes/darkTheme.ts
@@ -50,6 +50,10 @@ export const darkTheme = {
   topBarBorderColor: colorBorder,
   topBarButtonActiveColor: colorWhite,
   topBarButtonInactiveColor: colorGray,
+  unusedLabelBackgroundColor: colorError,
+  unusedLabelTextColor: colorWhite,
   uploadDropAreaBackgroundColor: 'rgba(0, 0, 0, 0.8)',
   uploadDropAreaIconColor: colorWhite,
+  usedLabelBackgroundColor: colorWhite,
+  usedLabelTextColor: colorGray,
 };

--- a/src/themes/lightTheme.ts
+++ b/src/themes/lightTheme.ts
@@ -51,6 +51,10 @@ export const lightTheme = {
   topBarBorderColor: colorBorder,
   topBarButtonActiveColor: colorBlack,
   topBarButtonInactiveColor: colorGrayLight,
+  unusedLabelBackgroundColor: colorError,
+  unusedLabelTextColor: colorWhite,
   uploadDropAreaBackgroundColor: 'rgba(0, 0, 0, 0.8)',
   uploadDropAreaIconColor: colorWhite,
+  usedLabelBackgroundColor: colorWhite,
+  usedLabelTextColor: colorGray,
 };

--- a/studio/plugins/sanity-plugin-media-library
+++ b/studio/plugins/sanity-plugin-media-library
@@ -1,1 +1,0 @@
-/Users/Aratramba/Documents/opensource/sanity-plugin-media-library

--- a/studio/plugins/sanity-plugin-media-library
+++ b/studio/plugins/sanity-plugin-media-library
@@ -1,0 +1,1 @@
+/Users/Aratramba/Documents/opensource/sanity-plugin-media-library


### PR DESCRIPTION
* used/unused tag for filtering
* unused / used by x documents message in edit dialog
* used by x documents in delete confirm dialog

Maybe someday add links to documents using an asset, but I think this will do for now.

![Screenshot 2021-02-09 at 16 09 45](https://user-images.githubusercontent.com/580312/107383529-5e7f5d80-6af1-11eb-8322-0a613f168df8.png)

![Screenshot 2021-02-09 at 16 09 55](https://user-images.githubusercontent.com/580312/107383533-60492100-6af1-11eb-9f86-9aac8b41413a.png)

![Screenshot 2021-02-09 at 16 10 02](https://user-images.githubusercontent.com/580312/107383536-60e1b780-6af1-11eb-9261-fbc1de97a44c.png)

![Screenshot 2021-02-09 at 16 10 09](https://user-images.githubusercontent.com/580312/107383541-617a4e00-6af1-11eb-86ff-7179694b8539.png)

![Screenshot 2021-02-09 at 16 10 33](https://user-images.githubusercontent.com/580312/107383544-62ab7b00-6af1-11eb-8acf-4c6bb5bf28dc.png)
